### PR TITLE
Fix ajax setup test

### DIFF
--- a/jquery.liteuploader.js
+++ b/jquery.liteuploader.js
@@ -167,7 +167,7 @@ LiteUploader.prototype = {
             url: this.options.script,
             type: 'POST',
             data: formData,
-            headers: this.options.headers,
+            headers: this.options.headers || {},
             processData: false,
             contentType: false
         })

--- a/tests/spec/jquery.liteuploader.spec.js
+++ b/tests/spec/jquery.liteuploader.spec.js
@@ -315,6 +315,7 @@ describe('Lite Uploader', function () {
                 url: 'abc',
                 type: 'POST',
                 data: 'form-data',
+                headers: {},
                 processData: false,
                 contentType: false
             });

--- a/tests/spec/jquery.liteuploader.spec.js
+++ b/tests/spec/jquery.liteuploader.spec.js
@@ -321,6 +321,20 @@ describe('Lite Uploader', function () {
             });
         });
 
+        it('should setup the ajax call with header', function () {
+            var headers = {'x-my-custom-header': 'some value'};
+            var options = {script: 'abc', params: {foo: '123'}, headers: headers};
+            var liteUploader = new LiteUploader(fileInput, options);
+            var deferred = $.Deferred();
+
+            spyOn($, 'ajax').and.returnValue(deferred);
+            liteUploader._performUpload('form-data');
+
+            expect($.ajax).toHaveBeenCalled();
+            expect($.ajax.calls.argsFor(0)[0]).not.toBeUndefined();
+            expect($.ajax.calls.argsFor(0)[0].headers).toEqual(headers);
+        });
+
         it('should trigger success event on success', function () {
             var liteUploader = new LiteUploader(fileInput, {script: 'abc', params: {foo: '123'}});
             var deferred = $.Deferred();


### PR DESCRIPTION
Test case: "perform upload should setup the ajax call correctly" was failing because of the `headers` option introduced in https://github.com/burt202/lite-uploader/pull/14. This PR takes care of that and adds an additional test to cover the `headers` option