### PR TITLE
Perform uploads per file, and delay request.

### DIFF
--- a/examples/multiple-single-request.html
+++ b/examples/multiple-single-request.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Multiple LiteUploader Example With Single Requests</title>
+
+	<style>
+
+		body {
+			font-family: helvetica;
+			font-size: 13px;
+		}
+
+	</style>
+</head>
+<body>
+  <p>In this example each file of a selection using an individual request.</p>
+
+  <input type="file" name="fileUpload2[]" id="fileUpload2" class="fileUpload" multiple="multiple" />
+	<div id="display"></div>
+	<div id="previews"></div>
+
+	<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+	<script src="../jquery.liteuploader.js"></script>
+	<script>
+
+		$(document).ready(function () {
+			$('.fileUpload').liteUploader({
+				script: 'multiple.php',
+        // Each file of a selection using an individual request.
+        singleFileUploads: true,
+				rules: {
+					allowedFileTypes: 'image/jpeg,image/png,image/gif',
+          maxSize: 250000
+				}
+			})
+      .on('lu:start', function () {
+        $('#previews').html('');
+      })
+			.on('lu:errors', function (e, errors) {
+				var isErrors = false;
+				$('#display').html('');
+
+				$.each(errors, function (i, error) {
+					if (error.errors.length > 0) {
+						isErrors = true;
+						$.each(error.errors, function (i, errorInfo) {
+							$('#display').append('<br />ERROR! File: ' + error.name + ' - Info: ' + JSON.stringify(errorInfo));
+						});
+					}
+				});
+
+				if (!isErrors) {
+					$('#display').append('<br />No errors');
+				}
+			})
+			.on('lu:before', function (e, files) {
+				$('#display').append('<br />Uploading ' + files.length + ' file(s)...');
+			})
+			.on('lu:progress', function (e, percentage) {
+				$('#display').append('<br />Progress ' + percentage + '%<br />');
+			})
+			.on('lu:success', function (e, response) {
+				var response = $.parseJSON(response);
+
+				$.each(response.urls, function(i, url) {
+					$('#previews').append($('<img>', {'src': url, 'width': 200}));
+				});
+
+				$('#display').append(response.message);
+			});
+		});
+
+	</script>
+</body>
+</html>

--- a/examples/multiple-single-request.html
+++ b/examples/multiple-single-request.html
@@ -13,9 +13,9 @@
 	</style>
 </head>
 <body>
-  <p>In this example each file of a selection using an individual request.</p>
+	<p>In this example each file of a selection using an individual request.</p>
 
-  <input type="file" name="fileUpload2[]" id="fileUpload2" class="fileUpload" multiple="multiple" />
+	<input type="file" name="fileUpload2[]" id="fileUpload2" class="fileUpload" multiple="multiple" />
 	<div id="display"></div>
 	<div id="previews"></div>
 
@@ -26,16 +26,21 @@
 		$(document).ready(function () {
 			$('.fileUpload').liteUploader({
 				script: 'multiple.php',
-        // Each file of a selection using an individual request.
-        singleFileUploads: true,
+				// Each file of a selection using an individual request.
+				singleFileUploads: true,
+				// Perform async operation before every file upload
+				// Useful to get a 3rd party token or authenticate user.
+				beforeRequest: function (files, formData) {
+					return $.when(formData);
+				},
 				rules: {
 					allowedFileTypes: 'image/jpeg,image/png,image/gif',
-          maxSize: 250000
+					maxSize: 250000
 				}
 			})
-      .on('lu:start', function () {
-        $('#previews').html('');
-      })
+			.on('lu:start', function () {
+				$('#previews').html('');
+			})
 			.on('lu:errors', function (e, errors) {
 				var isErrors = false;
 				$('#display').html('');

--- a/jquery.liteuploader.js
+++ b/jquery.liteuploader.js
@@ -54,6 +54,7 @@ LiteUploader.prototype = {
             this.el.trigger('lu:errors', errors);
             this._resetInput();
         } else {
+            this.el.trigger('lu:start', files);
             if (this.options.singleFileUploads) {
                 $.each(files, function (i) {
                     this._startUploadWithFiles([files[i]]);

--- a/jquery.liteuploader.js
+++ b/jquery.liteuploader.js
@@ -10,7 +10,10 @@ $.fn.liteUploader = function (options) {
         params: {},
         headers: {},
         changeHandler: true,
-        clickElement: null
+        clickElement: null,
+        // By default file selections are uploaded in one request each.
+        // Set to true to upload each file of a selection using an individual request.
+        singleFileUploads: false
     };
 
     return this.each(function () {
@@ -22,7 +25,7 @@ function LiteUploader (element, options) {
     this.el = $(element);
     this.options = options;
     this.params = options.params;
-    this.xhr = this._buildXhrObject();
+    this.xhrs = [];
 
     this._init();
 }
@@ -51,9 +54,19 @@ LiteUploader.prototype = {
             this.el.trigger('lu:errors', errors);
             this._resetInput();
         } else {
-            this.el.trigger('lu:before', [files]);
-            this._performUpload(this._collateFormData(files));
+            if (this.options.singleFileUploads) {
+                $.each(files, function (i) {
+                    this._startUploadWithFiles([files[i]]);
+                }.bind(this));
+            } else {
+                this._startUploadWithFiles(files);
+            }
         }
+    },
+
+    _startUploadWithFiles: function (files) {
+        this.el.trigger('lu:before', [files]);
+        this._performUpload(this._collateFormData(files));
     },
 
     _resetInput: function () {
@@ -154,16 +167,13 @@ LiteUploader.prototype = {
     _buildXhrObject: function () {
         var xhr = new XMLHttpRequest();
         xhr.upload.addEventListener('progress', this._onXHRProgress.bind(this), false);
+        this.xhrs.push(xhr);
         return xhr;
-    },
-
-    _getXHRObject: function () {
-        return this.xhr;
     },
 
     _performUpload: function (formData) {
         $.ajax({
-            xhr: this._getXHRObject.bind(this),
+            xhr: this._buildXhrObject.bind(this),
             url: this.options.script,
             type: 'POST',
             data: formData,
@@ -199,7 +209,9 @@ LiteUploader.prototype = {
     },
 
     cancelUpload: function () {
-        this.xhr.abort();
+        this.xhrs.forEach(function (xhr) {
+            xhr.abort();
+        });
         this.el.trigger('lu:cancelled');
         this._resetInput();
     }

--- a/jquery.liteuploader.js
+++ b/jquery.liteuploader.js
@@ -13,7 +13,10 @@ $.fn.liteUploader = function (options) {
         clickElement: null,
         // By default file selections are uploaded in one request each.
         // Set to true to upload each file of a selection using an individual request.
-        singleFileUploads: false
+        singleFileUploads: false,
+        // Delay the file upload request by returning a promise.
+        // File upload will start after the promise resolves with the formData.
+        beforeRequest: function (files, formData) { return $.when(formData); }
     };
 
     return this.each(function () {
@@ -62,7 +65,8 @@ LiteUploader.prototype = {
     _startUploadWithFiles: function (files) {
         function performUpload() {
             this.el.trigger('lu:before', [files]);
-            this._performUpload(this._collateFormData(files));
+            this.options.beforeRequest(files, this._collateFormData(files))
+                .done(this._performUpload.bind(this));
         }
 
         if (this.options.singleFileUploads) {

--- a/jquery.liteuploader.js
+++ b/jquery.liteuploader.js
@@ -55,19 +55,23 @@ LiteUploader.prototype = {
             this._resetInput();
         } else {
             this.el.trigger('lu:start', files);
-            if (this.options.singleFileUploads) {
-                $.each(files, function (i) {
-                    this._startUploadWithFiles([files[i]]);
-                }.bind(this));
-            } else {
-                this._startUploadWithFiles(files);
-            }
+            this._startUploadWithFiles(files);
         }
     },
 
     _startUploadWithFiles: function (files) {
-        this.el.trigger('lu:before', [files]);
-        this._performUpload(this._collateFormData(files));
+        function performUpload() {
+            this.el.trigger('lu:before', [files]);
+            this._performUpload(this._collateFormData(files));
+        }
+
+        if (this.options.singleFileUploads) {
+            $.each(files, function (i) {
+                performUpload.call(this, [files[i]]);
+            }.bind(this));
+        } else {
+            performUpload.call(this, files);
+        }
     },
 
     _resetInput: function () {

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,11 @@ The aim was to see, at its absolute minimum, how little code do you need to make
         <td>triggered after input and file validation - see 'File Error Types' section for more</td>
     </tr>
     <tr>
+        <td>lu:start</td>
+        <td>event, files</td>
+        <td>triggered before any uploading starts, after the clickElement click event or the change handler - fires once per file selection</td>
+    </tr>
+    <tr>
         <td>lu:before</td>
         <td>event, files</td>
         <td>triggered before the uploading starts</td>

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,12 @@ The aim was to see, at its absolute minimum, how little code do you need to make
         <td>null</td>
         <td>initiate the upload on the click event of the jQuery element passed here</td>
     </tr>
+    <tr>
+        <td>singleFileUploads</td>
+        <td>Boolean</td>
+        <td>false</td>
+        <td>set to true to upload each file of a selection using an individual request</td>
+    </tr>
 </table>
 
 ### Events

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,11 @@ The aim was to see, at its absolute minimum, how little code do you need to make
         <td>false</td>
         <td>set to true to upload each file of a selection using an individual request</td>
     </tr>
+    <tr>
+        <td>beforeRequest</td>
+        <td>Function</td>
+        <td colspan="2">Delay the file upload request by returning a promise. Recieves the Files and the FormData. Expected to resolve with the FormData to continue. Reject to stop upload.</td>
+    </tr>
 </table>
 
 ### Events

--- a/tests/spec/jquery.liteuploader.spec.js
+++ b/tests/spec/jquery.liteuploader.spec.js
@@ -79,13 +79,29 @@ describe('Lite Uploader', function () {
             expect(liteUploader._performUpload).not.toHaveBeenCalled();
         });
 
+        it('should not proceed with upload if beforeRequest was rejected', function () {
+            spyOn(LiteUploader.prototype, '_getInputErrors').and.returnValue(null);
+            spyOn(LiteUploader.prototype, '_getFileErrors').and.returnValue(null);
+            spyOn(LiteUploader.prototype, '_resetInput');
+            spyOn(LiteUploader.prototype, '_collateFormData').and.returnValue('collated');
+            spyOn(LiteUploader.prototype, '_performUpload');
+            var beforeRequest = function (files, formData) { return $.Deferred().reject(); };
+            var liteUploader = new LiteUploader(fileInput, {script: 'script', beforeRequest: beforeRequest});
+
+            liteUploader._start();
+
+            expect(liteUploader._resetInput).not.toHaveBeenCalled();
+            expect(liteUploader._performUpload).not.toHaveBeenCalled();
+        });
+
         it('should proceed with upload if no errors are found', function () {
             spyOn(LiteUploader.prototype, '_getInputErrors').and.returnValue(null);
             spyOn(LiteUploader.prototype, '_getFileErrors').and.returnValue(null);
             spyOn(LiteUploader.prototype, '_resetInput');
             spyOn(LiteUploader.prototype, '_collateFormData').and.returnValue('collated');
             spyOn(LiteUploader.prototype, '_performUpload');
-            var liteUploader = new LiteUploader(fileInput, {script: 'script'});
+            var beforeRequest = function (files, formData) { return $.when(formData); };
+            var liteUploader = new LiteUploader(fileInput, {script: 'script', beforeRequest: beforeRequest});
             spyOn(liteUploader.el, 'trigger');
 
             liteUploader._start();

--- a/tests/spec/jquery.liteuploader.spec.js
+++ b/tests/spec/jquery.liteuploader.spec.js
@@ -10,14 +10,12 @@ describe('Lite Uploader', function () {
         it('should be able to be instantiated', function () {
             spyOn(LiteUploader.prototype, '_init');
 
-            spyOn(LiteUploader.prototype, '_buildXhrObject').and.returnValue('xhrObject');
             var liteUploader = new LiteUploader(fileInput, {tester: 'abc', params: {foo: '123'}});
 
             expect(liteUploader).toBeTruthy();
             expect(liteUploader.el).toEqual(jasmine.any(Object));
             expect(liteUploader.options).toEqual({tester: 'abc', params: {foo: '123'}});
             expect(liteUploader.params).toEqual({foo: '123'});
-            expect(liteUploader.xhr).toEqual('xhrObject');
             expect(liteUploader._init).toHaveBeenCalled();
         });
     });
@@ -286,19 +284,8 @@ describe('Lite Uploader', function () {
 
             liteUploader._buildXhrObject();
 
-            expect(liteUploader.xhr instanceof XMLHttpRequest).toBeTruthy();
+            expect(liteUploader.xhrs[0] instanceof XMLHttpRequest).toBeTruthy();
             expect(XMLHttpRequestUpload.prototype.addEventListener).toHaveBeenCalledWith('progress', jasmine.any(Function), false);
-        });
-    });
-
-    describe('get xhr object', function () {
-        it('should return the xhr variable', function () {
-            var liteUploader = new LiteUploader(fileInput, {script: 'abc', params: {foo: '123'}});
-
-            liteUploader.xhr = 'abc';
-            var result = liteUploader._getXHRObject();
-
-            expect(result).toEqual('abc');
         });
     });
 
@@ -409,15 +396,15 @@ describe('Lite Uploader', function () {
     describe('cancel upload', function () {
         it('should abort the xhr object, trigger cancelled event and reset the input', function () {
             var liteUploader = new LiteUploader(fileInput, {tester: 'abc', params: {foo: '123'}});
-            liteUploader.xhr = {
+            liteUploader.xhrs = [{
                 abort: jasmine.createSpy()
-            };
+            }];
 
             spyOn(liteUploader.el, 'trigger');
             spyOn(liteUploader, '_resetInput');
             liteUploader.cancelUpload();
 
-            expect(liteUploader.xhr.abort).toHaveBeenCalled();
+            expect(liteUploader.xhrs[0].abort).toHaveBeenCalled();
             expect(liteUploader.el.trigger).toHaveBeenCalledWith('lu:cancelled');
             expect(liteUploader._resetInput).toHaveBeenCalled();
         });


### PR DESCRIPTION
1. Adds the ability to upload multiple files but perform a single upload request for each of them.
2. Adds the ability to delay a file upload until an other operation finishes.

Both are required to operate this file upload plugin with 3rd party services like cloudinary, where you have to get a token for every file and upload individual files using their secure token.

**singleFileUploads** upload every selected file in it's own request.
**beforeRequest** delay uploading.

Example `beforeRequest` callback:
```javascript
// beforeRequest is called for every file when singleFileUploads is true
function beforeRequest(fileList, formData) {
	// Get token from Cloudinary for the file
	return cloudinaryRequest.getSignedRequest(fileList[0].name).then(function (signedRequest) {
		// Attach token to formData 
		formData.append('token', signedRequest.token);
		// Return with formData to start file upload
		return formData;
	});
}
```